### PR TITLE
Avoid GCC-7 & above compiler warning: -Wimplicit-fallthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ If you define DEBUG you will see debug output when using pprint. This looks like
 Which is nice when proving things are parsing as you expect. 
 
 ##api
+
 	list<EdnToken> lex(string ednString)
 	
 	EdnNode read(string ednString)
@@ -87,6 +88,7 @@ Which is nice when proving things are parsing as you expect.
 	EdnNode handleTagged(EdnToken token, EdnNode value)
 	
 ##structs
+
 	EdnToken
 		TokenType type
 		int line
@@ -99,6 +101,7 @@ Which is nice when proving things are parsing as you expect.
 		list<EdnNode> values #used for collections
 		
 ##enums
+
 	TokenType
 		TokenString
 		TokenAtom

--- a/edn.hpp
+++ b/edn.hpp
@@ -384,13 +384,10 @@ namespace edn {
     after.reserve(before.length() + 4); 
     
     for (string::size_type i = 0; i < before.length(); ++i) { 
-      switch (before[i]) { 
-        case '"':
-        case '\\':
+      if (before[i] == '"' || before[i] == '\\') {
           after += '\\';
-        default:
-          after += before[i];
       }
+      after += before[i];
     }
     return after;
   }


### PR DESCRIPTION
With current master and GCC 7 or above (GCC 9 in this specific example) I see:
```
$ g++-9 -Wextra  example.cpp
In file included from example.cpp:2:
edn.hpp: In function 'std::string edn::escapeQuotes(const string&)':
edn.hpp:390:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
  390 |           after += '\\';
      |                    ^~~~
edn.hpp:391:9: note: here
  391 |         default:
      |         ^~~~~~~
```
To avoid this, I've switched to an equivalent `if()` statement.